### PR TITLE
Updating mongodb client to 1.3.18, 1.3.17 has memory leak

### DIFF
--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@ Package.describe({
 });
 
 Npm.depends({
-  'mongodb': '1.3.17'
+  'mongodb': '1.3.18'
 });
 
 Package.on_use(function(api) {


### PR DESCRIPTION
v1.3.17 has a memory leak, it was fixed 2 days ago.

the commit is here: https://github.com/mongodb/node-mongodb-native/commit/8a31908c6ae0e0de5c93bb3a39a847ca89c6cdc3
